### PR TITLE
Add passthrough streams as stdout/stderr buffer

### DIFF
--- a/test.js
+++ b/test.js
@@ -390,3 +390,18 @@ test('nanoprocess() - pipe stdio', (t) => {
     })
   })
 })
+
+test('nanoprocess() - stdout works', t => {
+  const child = nanoprocess('echo', ['foo'])
+  child.open((err) => {
+    t.error(err)
+    let timeout = setTimeout(() => {
+      t.error(new Error('Data was not received'))
+    }, 100)
+    child.stdout.once('data', data => {
+      t.equal(data.toString(), 'foo\n')
+      clearTimeout(timeout)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
This is a potential fix for #2. The patch adds PassThrough streams for stdout and stderr to capture output that the socket emits before the `open()` callback of the nanoprocess is invoked (which is after at least one `nextTick` due to async stats collection that happens after spawning).

The included test passes with and fails without the changes in index.js.